### PR TITLE
Problem with login to pre 6.43 devices

### DIFF
--- a/src/RouterOSAPI.ts
+++ b/src/RouterOSAPI.ts
@@ -427,10 +427,10 @@ export class RouterOSAPI extends EventEmitter {
 
                     const challenge = Buffer.alloc(this.password.length + 17);
                     const challengeOffset = this.password.length + 1;
-                    const ret = data[0].ret;
+                    const ret = data[0].ret; // here we have 32 chars with hex encoded 16 bytes of challange data
 
                     challenge.write(String.fromCharCode(0) + this.password);
-                    challenge.write(ret, challengeOffset, ret.length, 'hex');
+                    challenge.write(ret, challengeOffset, ret.length / 2 /* to write 32 hec chars to buffer as bytes we need to really write 16 bytes */, 'hex');
 
                     const resp =
                         '00' +


### PR DESCRIPTION
node: v10.16.3
node-routeros: 1.6.2
router os: 6.42.11 (long-term)

I've encountered problems with connection to factory new LtAP mini devices. Out of the box they come with 6.42.11 (long-term) routeros version and old login scheme. Default connection parameters are `192.168.88.1` with credentials `admin` and empty password.

Connection on default parameters resulted in:

```
RangeError [ERR_OUT_OF_RANGE]: The value of "length" is out of range. It must be >= 0 && <= 17. Received 31
[1]     at Buffer.write (buffer.js:907:7)
[1]     at node_modules/node-routeros/dist/RouterOSAPI.js:342:27
[1]     at processTicksAndRejections (internal/process/task_queues.js:89:5)
```
After a while of digging i tracked problematic lines. After login action server responsc with chellange data. `ret` field contains 32 characters encoding 16 bytes of data.

While writing response buffer you used `ret.length` which is 32 and hex encoder which is wrong. You previously alocated 16 butes for that purpose. Dividing `ret.length` by 2 fixes the problem.

Changes are in commit. I hope this is correct fix. By now i use my fork but i would gladly switch back to your project if you merge them.

Thanks for the great lib. 